### PR TITLE
Fix parsing of GitHub Action boolean inputs

### DIFF
--- a/avrolint.js
+++ b/avrolint.js
@@ -6,12 +6,12 @@ let avrolint = function(avscFilePath, options={"undocumentedCheck": true, "compl
   return new Promise((resolve) => {
     // default, assume input is single file
     var filePaths = [avscFilePath];
-		try {
+    try {
       // try to see if it's a list of paths in JSON array
       filePaths = JSON.parse(avscFilePath);
     }
     catch (err) {
-			// ignore
+      // ignore
     }
 
     var filePathsWithErrors = new Set();
@@ -93,7 +93,7 @@ let isOrContainsRecord = function(field) {
 }
 
 let isUnionType = function(type) {
-	return Array.isArray(type);
+  return Array.isArray(type);
 }
 
 let getRecordSchema = function(field) {
@@ -136,7 +136,7 @@ let getUnionSchema = function(field) {
   if (upperCaseFieldType === "ARRAY" && isUnionType(field.type.items)) {
     return field.type.items;
   } else if (upperCaseFieldType === "MAP" && isUnionType(field.type.values)) {
-    return field.type.values;
+     return field.type.values;
   }
 
 }

--- a/index.js
+++ b/index.js
@@ -5,11 +5,11 @@ async function run() {
   try {
     // 'avsc-to-lint' input defined in action metadata file
     const avscToLint = core.getInput('avsc-to-lint', {required: true});
-    const undocumentedCheck = core.getInput(
+    const undocumentedCheck = core.getBooleanInput(
       'undocumented-field-check',
       {required: true}
     );
-		const complexUnionCheck = core.getInput(
+		const complexUnionCheck = core.getBooleanInput(
       'complex-union-check',
       {required: true}
     );

--- a/index.js
+++ b/index.js
@@ -9,17 +9,17 @@ async function run() {
       'undocumented-field-check',
       {required: true}
     );
-		const complexUnionCheck = core.getBooleanInput(
+    const complexUnionCheck = core.getBooleanInput(
       'complex-union-check',
       {required: true}
     );
     console.log(`Linting ${avscToLint}!`);
     await avrolint(
       avscToLint,
-			{
+      {
         "undocumentedCheck": undocumentedCheck,
         "complexUnionCheck": complexUnionCheck
-			}
+      }
     );
   } catch (error) {
     console.error(error.stack);

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
     "test": "jest",
     "all": "npm run lint && npm run prepare && npm run test"
   },
+  "eslintConfig": {
+    "extends": "eslint:recommended"
+  },
   "dependencies": {
     "@actions/core": "^1.10.0",
     "avro-js": "^1.11.1"


### PR DESCRIPTION
GitHub Action inputs are always strings. The existing code assumed, incorrectly, that it could receive booleans, and thus interpreted its inputs, made of non-empty strings, as true.